### PR TITLE
hoxfix: 프로필 이미지가 post_images S3로 넘어가는 코드 에러 수정

### DIFF
--- a/src/main/java/org/gamja/gamzatechblog/domain/profileimage/service/impl/ProfileImageServiceImpl.java
+++ b/src/main/java/org/gamja/gamzatechblog/domain/profileimage/service/impl/ProfileImageServiceImpl.java
@@ -34,7 +34,7 @@ public class ProfileImageServiceImpl implements ProfileImageService {
 	private final @Qualifier("profileImageMapperImpl") ProfileImageMapper mapper;
 	private final UserRepository userRepository;
 
-	private static final String POST_IMAGES_PREFIX = "post-images";
+	private static final String POST_IMAGES_PREFIX = "profile-images";
 	// @Override
 	// @Transactional
 	// public ProfileImage uploadProfileImage(MultipartFile file, User user) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the storage prefix for profile image uploads, ensuring profile images are stored with a more accurate identifier. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->