### PR TITLE
fix: S3업로드 용량 낮춤

### DIFF
--- a/src/main/java/org/gamja/gamzatechblog/domain/profileimage/validator/ProfileImageValidator.java
+++ b/src/main/java/org/gamja/gamzatechblog/domain/profileimage/validator/ProfileImageValidator.java
@@ -23,7 +23,7 @@ public class ProfileImageValidator {
 
 	private final ProfileImageRepository profileImageRepository;
 	private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png", "gif");
-	private static final long MAX_FILE_SIZE = 5 * 1024 * 1024;
+	private static final long MAX_FILE_SIZE = 3L * 1024 * 1024;
 
 	public void validateFile(MultipartFile file) {
 		if (file == null || file.isEmpty()) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,8 +10,8 @@ spring:
 
   servlet:
     multipart:
-      max-file-size: 7MB
-      max-request-size: 7MB
+      max-file-size: 3MB
+      max-request-size: 3MB
 
   jpa:
     hibernate:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the maximum allowed profile image upload size from 5MB to 3MB.
  * Reduced the maximum allowed file and request size for uploads in the application settings from 7MB to 3MB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->