### PR TITLE
hotfix: refreshToken 재발급 로직 및 쿠키 처리 수정

### DIFF
--- a/src/main/java/org/gamja/gamzatechblog/core/auth/controller/UserAuthController.java
+++ b/src/main/java/org/gamja/gamzatechblog/core/auth/controller/UserAuthController.java
@@ -34,17 +34,15 @@ public class UserAuthController {
 	@PostMapping("/reissue")
 	public ResponseDto<AccessTokenResponse> reissue(
 		@CookieValue(value = "refreshToken", required = false) String oldRefresh, HttpServletResponse response) {
-		// 1) 쿠키가 없으면 401 Unauthorized
 		if (oldRefresh == null) {
 			return ResponseDto.of(
 				HttpStatus.UNAUTHORIZED,
-				"리프레시 토큰이 없습니다.", //수정 예정입니다.
+				"리프레시 토큰이 없습니다.",
 				null
 			);
 		}
 		TokenResponse tokens = authService.reissueRefreshToken(oldRefresh);
 		cookieUtils.addAccessTokenCookie(response, tokens.getAccessToken(), DOMAIN, ACCESS_TOKEN_TTL);
-		cookieUtils.addRefreshTokenCookie(response, tokens.getRefreshToken(), DOMAIN, REFRESH_TOKEN_TTL);
 		AccessTokenResponse body = new AccessTokenResponse(tokens.getAccessToken());
 		return ResponseDto.of(HttpStatus.OK, "토큰 재발급 성공", body);
 	}

--- a/src/main/java/org/gamja/gamzatechblog/core/auth/oauth/dao/RefreshTokenDao.java
+++ b/src/main/java/org/gamja/gamzatechblog/core/auth/oauth/dao/RefreshTokenDao.java
@@ -39,4 +39,9 @@ public class RefreshTokenDao {
 		redis.opsForValue().set(TOKEN_PREFIX + newToken, userId, ttl);
 		redis.opsForValue().set(USER_TOKEN_KEY + userId, newToken, ttl);
 	}
+
+	public void touchTtl(String refreshToken, Duration ttl) {
+		String key = "refresh:" + refreshToken;
+		redis.expire(key, ttl);
+	}
 }

--- a/src/main/java/org/gamja/gamzatechblog/core/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/org/gamja/gamzatechblog/core/auth/service/impl/AuthServiceImpl.java
@@ -46,7 +46,11 @@ public class AuthServiceImpl implements AuthService {
 	public TokenResponse reissueRefreshToken(String oldRefreshToken) {
 		String userId = refreshTokenDao.findUserIdByRefreshToken(oldRefreshToken)
 			.orElseThrow(() -> new OAuthException(ErrorCode.JWT_NOT_FOUND));
-		return issueTokens(userId);
+
+		String accessToken = jwtProvider.createAccessToken(userId);
+		refreshTokenDao.touchTtl(oldRefreshToken, REFRESH_TOKEN_TTL);
+
+		return new TokenResponse(accessToken, oldRefreshToken);
 	}
 
 	@Override


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamlined session refresh: only the access token is updated during renewal; the existing refresh token remains unchanged.
  * Reduced cookie updates on the reissue endpoint, minimizing disruptions during ongoing sessions.
  * Consistent response body continues to include only the access token.

* **Refactor**
  * Internal changes to how refresh token validity is maintained without rotating tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->