### PR TITLE
test: 텃밭인사 서비스 Test코드 추가

### DIFF
--- a/src/test/java/org/gamja/gamzatechblog/domain/intro/service/IntroServiceTest.java
+++ b/src/test/java/org/gamja/gamzatechblog/domain/intro/service/IntroServiceTest.java
@@ -1,0 +1,94 @@
+package org.gamja.gamzatechblog.domain.intro.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.gamja.gamzatechblog.common.dto.PagedResponse;
+import org.gamja.gamzatechblog.domain.intro.service.port.IntroductionFakeRepository;
+import org.gamja.gamzatechblog.domain.introduction.model.dto.response.IntroResponse;
+import org.gamja.gamzatechblog.domain.introduction.model.entity.Introduction;
+import org.gamja.gamzatechblog.domain.introduction.model.mapper.IntroMapper;
+import org.gamja.gamzatechblog.domain.introduction.service.IntroService;
+import org.gamja.gamzatechblog.domain.introduction.service.impl.IntroServiceImpl;
+import org.gamja.gamzatechblog.domain.introduction.service.port.IntroductionRepository;
+import org.gamja.gamzatechblog.domain.introduction.validator.IntroValidator;
+import org.gamja.gamzatechblog.domain.user.model.entity.User;
+import org.gamja.gamzatechblog.support.intro.IntroFixtures;
+import org.gamja.gamzatechblog.support.user.UserFixtures;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+
+@DisplayName("IntroService 단위 테스트")
+class IntroServiceTest {
+
+	private IntroService introService;
+	private IntroductionRepository introductionRepository;
+	private IntroMapper introMapper;
+	private IntroValidator introValidator;
+
+	@BeforeEach
+	void setUp() {
+		introductionRepository = new IntroductionFakeRepository();
+		introMapper = mock(IntroMapper.class);
+		introValidator = mock(IntroValidator.class);
+
+		introService = new IntroServiceImpl(
+			introductionRepository,
+			introMapper,
+			introValidator
+		);
+	}
+
+	@Test
+	@DisplayName("소개글 생성 성공")
+	void create_success() {
+		User user = UserFixtures.user("git-a");
+		String content = IntroFixtures.content("첫번째");
+
+		Introduction newIntro = mock(Introduction.class);
+		IntroResponse expected = mock(IntroResponse.class);
+
+		doNothing().when(introValidator).validateNotExists(user);
+		when(introMapper.newIntroduction(user, content)).thenReturn(newIntro);
+		when(introMapper.toResponse(newIntro)).thenReturn(expected);
+
+		IntroResponse result = introService.create(user, content);
+
+		assertThat(result).isSameAs(expected);
+		verify(introValidator).validateNotExists(user);
+		verify(introMapper).newIntroduction(user, content);
+		verify(introMapper).toResponse(newIntro);
+	}
+
+	@Test
+	@DisplayName("소개글 목록 페이징 조회")
+	void list_success() {
+		User user = UserFixtures.user("git-list");
+		introductionRepository.save(IntroFixtures.introduction(user, "첫번째"));
+		introductionRepository.save(IntroFixtures.introduction(user, "두번째"));
+
+		PagedResponse<IntroResponse> page0 = introService.list(PageRequest.of(0, 10));
+
+		assertThat(page0.totalElements()).isEqualTo(2);
+	}
+
+	@Test
+	@DisplayName("소개글 삭제 성공")
+	void delete_success() {
+		User user = UserFixtures.user("git-z");
+		Introduction intro = mock(Introduction.class);
+
+		introductionRepository.save(intro);
+
+		when(introValidator.validateExists(1L)).thenReturn(intro);
+		doNothing().when(introValidator).validateOwner(intro, user);
+
+		introService.delete(1L, user);
+
+		assertThat(introductionRepository.findAll(PageRequest.of(0, 10)).getTotalElements()).isZero();
+		verify(introValidator).validateExists(1L);
+		verify(introValidator).validateOwner(intro, user);
+	}
+}

--- a/src/test/java/org/gamja/gamzatechblog/domain/intro/service/port/IntroductionFakeRepository.java
+++ b/src/test/java/org/gamja/gamzatechblog/domain/intro/service/port/IntroductionFakeRepository.java
@@ -1,0 +1,68 @@
+package org.gamja.gamzatechblog.domain.intro.service.port;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.gamja.gamzatechblog.domain.introduction.model.entity.Introduction;
+import org.gamja.gamzatechblog.domain.introduction.service.port.IntroductionRepository;
+import org.gamja.gamzatechblog.domain.user.model.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+public class IntroductionFakeRepository implements IntroductionRepository {
+
+	private final Map<Long, Introduction> store = new LinkedHashMap<>();
+	private final AtomicLong seq = new AtomicLong(1L);
+
+	@Override
+	public boolean existsByUser(User user) {
+		return store.values().stream()
+			.anyMatch(intro -> intro.getUser().equals(user));
+	}
+
+	@Override
+	public Optional<Introduction> findByUser(User user) {
+		return store.values().stream()
+			.filter(intro -> intro.getUser().equals(user))
+			.findFirst();
+	}
+
+	@Override
+	public Optional<Introduction> findById(Long introId) {
+		return Optional.ofNullable(store.get(introId));
+	}
+
+	// 새 엔티티라면 id를 새로 부여
+	@Override
+	public Introduction save(Introduction intro) {
+		if (intro.getId() == null) {
+			try {
+				var idField = Introduction.class.getDeclaredField("id");
+				idField.setAccessible(true);
+				idField.set(intro, seq.getAndIncrement());
+			} catch (Exception ignored) {
+			}
+		}
+		store.put(intro.getId(), intro);
+		return intro;
+	}
+
+	@Override
+	public void delete(Introduction intro) {
+		store.remove(intro.getId());
+	}
+
+	@Override
+	public Page<Introduction> findAll(Pageable pageable) {
+		List<Introduction> all = new ArrayList<>(store.values());
+		int start = (int)Math.min(pageable.getOffset(), all.size());
+		int end = Math.min(start + pageable.getPageSize(), all.size());
+		List<Introduction> content = all.subList(start, end);
+		return new PageImpl<>(content, pageable, all.size());
+	}
+}

--- a/src/test/java/org/gamja/gamzatechblog/domain/post/service/PostServiceTest.java
+++ b/src/test/java/org/gamja/gamzatechblog/domain/post/service/PostServiceTest.java
@@ -31,6 +31,7 @@ import org.gamja.gamzatechblog.domain.postimage.service.PostImageService;
 import org.gamja.gamzatechblog.domain.posttag.util.PostTagUtil;
 import org.gamja.gamzatechblog.domain.repository.model.entity.GitHubRepo;
 import org.gamja.gamzatechblog.domain.repository.port.GitHubRepoRepository;
+import org.gamja.gamzatechblog.domain.tag.service.TagService;
 import org.gamja.gamzatechblog.domain.tag.service.port.TagRepository;
 import org.gamja.gamzatechblog.domain.user.model.entity.User;
 import org.gamja.gamzatechblog.support.post.PostFixtures;
@@ -63,6 +64,8 @@ class PostServiceTest {
 	private PostProcessingService postProcessingService;
 	private CommitHistoryRepository commitHistoryRepository;
 
+	private TagService tagService;
+
 	private CacheManager cacheManager;
 
 	private PostServiceImpl service;
@@ -86,6 +89,7 @@ class PostServiceTest {
 		postImageService = mock(PostImageService.class);
 		postProcessingService = mock(PostProcessingService.class);
 		commitHistoryRepository = mock(CommitHistoryRepository.class);
+		tagService = mock(TagService.class);
 
 		cacheManager = new ConcurrentMapCacheManager(
 			"hotPosts", "postDetail", "postsList", "myPosts", "searchPosts", "postsByTag", "allTags"
@@ -95,7 +99,7 @@ class PostServiceTest {
 			postRepository, postMapper, postValidator, githubTokenValidator,
 			gitHubRepoRepository, postTagUtil, tagRepository, commentService,
 			postDetailMapper, postQueryPort, postPopularMapper, postImageService,
-			postProcessingService, commitHistoryRepository, cacheManager
+			postProcessingService, commitHistoryRepository, cacheManager, tagService
 		);
 
 		user = PostFixtures.user(1L);

--- a/src/test/java/org/gamja/gamzatechblog/support/intro/IntroFixtures.java
+++ b/src/test/java/org/gamja/gamzatechblog/support/intro/IntroFixtures.java
@@ -1,0 +1,21 @@
+package org.gamja.gamzatechblog.support.intro;
+
+import org.gamja.gamzatechblog.domain.introduction.model.entity.Introduction;
+import org.gamja.gamzatechblog.domain.user.model.entity.User;
+
+public final class IntroFixtures {
+
+	private IntroFixtures() {
+	}
+
+	public static String content(String seed) {
+		return "소개글 내용 - " + seed;
+	}
+
+	public static Introduction introduction(User user, String seed) {
+		return Introduction.builder()
+			.user(user)
+			.content(content(seed))
+			.build();
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added comprehensive unit tests for the Intro service covering create, list, and delete scenarios.
  - Introduced an in-memory repository test double to support paging and CRUD in tests.
  - Added reusable fixtures for generating intro content and entities in test setups.
  - Updated post service tests to accommodate a new dependency on the tagging service.
- Chores
  - Improved test reliability and coverage across intro and post service areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->